### PR TITLE
fixes

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -39,6 +39,7 @@ https://learnopengl.com/Lighting/Basic-Lighting
 https://stackoverflow.com/questions/7223623/storing-different-vertex-attributes-in-different-vbos
 https://gamedev.stackexchange.com/questions/124295/how-to-hot-reload-a-glsl-shader
 https://gamedev.stackexchange.com/questions/47910/after-a-succesful-gllinkprogram-should-i-delete-detach-my-shaders
+https://community.khronos.org/t/memory-leak-on-shader-delete-and-create/64559/2 (important bit: call glUseProgram(0) before glDeleteProgram(shaderProgram))
 
 misc stuff ===================================================
 https://solarianprogrammer.com/2019/06/10/c-programming-reading-writing-images-stb_image-libraries/


### PR DESCRIPTION
- shader changes take effect immediately after the first button click now :) it seems all I needed was to set the current shader program to none (e.g. `glUseProgram(0)`) before deleting the old one and assigning a new one
-  mouse input (e.g. drag, clickwheel scroll) for 3d model display is now independent of the shader editors (e.g. scrolling in a shader editor should not zoom in/out on the 3d model)

![08-01-2025_201231](https://github.com/user-attachments/assets/35c4f3d8-2e05-4abe-bdf9-e64571def2e5)
